### PR TITLE
Update Anchors.tex Typo (+ subtile typographic setting)

### DIFF
--- a/docs/Anchors.tex
+++ b/docs/Anchors.tex
@@ -1,4 +1,4 @@
-The anchors are possibly the most imporant part of these figures since they allow you to connect these figures to the rest of your drawing. Therefore, we have tried to make the anchors as consistent as possible in terms of naming. The most common abbreviations for anchors that you will find in Section \ref{sec: Assets} are the following:
+The anchors are possibly the most important part of these figures since they allow you to connect these figures to the rest of your drawing. Therefore, we have tried to make the anchors as consistent as possible in terms of naming. The most common abbreviations for anchors that you will find in Section \ref{sec: Assets} are the following:
 
 \begin{center}
     \begin{tabular}{c|lcc|l}
@@ -23,4 +23,4 @@ The anchors are possibly the most imporant part of these figures since they allo
     \end{tabular}
 \end{center}
 
-Most assets will only use (a selection of) these anchors. \textbf{Not every anchor is defined for every asset. Please check the section of the asset to see which are defined for that asset.}  If it uses more than these, they are specified in the section of that asset, e.g. Tanks. 
+Most assets will only use (a selection of) these anchors. \textbf{Not every anchor is defined for every asset. Please check the section of the asset to see which are defined for that asset.}  If it uses more than these, they are specified in the section of that asset, e.g.~Tanks. 


### PR DESCRIPTION
LaTeX thick that a lowercase letter followed by a period followed by a space is the end of a sentence (Guide to LaTeX, 4th edition, Kopka & Daly, page 32). And by default, LaTeX uses a greater space at end of sentence than between word (unless the `\frenchspacing` command, from LaTeX kernel, is used). To avoid a wrong detection of end of sentence with `e.g. Tanks`, a `~` can be used instead of a simple ``.